### PR TITLE
Fix sampler uniform redefinition

### DIFF
--- a/shaders/lib/Materials.inc
+++ b/shaders/lib/Materials.inc
@@ -1,5 +1,10 @@
 // File: shaders/lib/Materials.inc
+// Terrain samplers are defined in Uniforms.inc.
+// Avoid redeclaration when this file is included after Uniforms.inc.
+#ifndef LAZY_TERRAIN_SAMPLERS_DEFINED
+#define LAZY_TERRAIN_SAMPLERS_DEFINED
 uniform sampler2D terrain;
 uniform sampler2D terrain_n;
 uniform sampler2D terrain_s;
+#endif
 vec4 GetTerrainColor(vec2 uv){return texture(terrain,uv);}

--- a/shaders/lib/Uniforms.inc
+++ b/shaders/lib/Uniforms.inc
@@ -23,3 +23,6 @@ uniform sampler2D colortex7;
 uniform sampler2D terrain;
 uniform sampler2D terrain_n;
 uniform sampler2D terrain_s;
+#ifndef LAZY_TERRAIN_SAMPLERS_DEFINED
+#define LAZY_TERRAIN_SAMPLERS_DEFINED
+#endif


### PR DESCRIPTION
## Summary
- avoid duplicate `terrain` uniforms by guarding the declarations
- guard the declarations from Uniforms.inc

## Testing
- `glslangValidator -S vert shaders/composite.vsh` *(fails: `'#include' : required extension not requested`)*

------
https://chatgpt.com/codex/tasks/task_e_68434d56fa5c83309d74e7e2c149da38