### PR TITLE
Fix terrain sampler redefinition

### DIFF
--- a/shaders/lib/Materials.inc
+++ b/shaders/lib/Materials.inc
@@ -1,10 +1,4 @@
 // File: shaders/lib/Materials.inc
-// Terrain samplers are defined in Uniforms.inc.
-// Avoid redeclaration when this file is included after Uniforms.inc.
-#ifndef LAZY_TERRAIN_SAMPLERS_DEFINED
-#define LAZY_TERRAIN_SAMPLERS_DEFINED
-uniform sampler2D terrain;
-uniform sampler2D terrain_n;
-uniform sampler2D terrain_s;
-#endif
+// Terrain samplers are provided by the shader loader.
+// Do not redeclare them here to avoid conflicts.
 vec4 GetTerrainColor(vec2 uv){return texture(terrain,uv);}

--- a/shaders/lib/Uniforms.inc
+++ b/shaders/lib/Uniforms.inc
@@ -20,9 +20,3 @@ uniform sampler2D colortex4;
 uniform sampler2D colortex5;
 uniform sampler2D colortex6;
 uniform sampler2D colortex7;
-uniform sampler2D terrain;
-uniform sampler2D terrain_n;
-uniform sampler2D terrain_s;
-#ifndef LAZY_TERRAIN_SAMPLERS_DEFINED
-#define LAZY_TERRAIN_SAMPLERS_DEFINED
-#endif


### PR DESCRIPTION
## Summary
- avoid declaring `terrain` samplers in shader includes

## Testing
- `glslangValidator -E -S vert -Ishaders -Ishaders/lib --P "#extension GL_GOOGLE_include_directive:enable" shaders/composite.vsh | grep -i error`
- `glslangValidator -E -S frag -Ishaders -Ishaders/lib --P "#extension GL_GOOGLE_include_directive:enable" shaders/composite.fsh | grep -i error`


------
https://chatgpt.com/codex/tasks/task_e_68434ee7fdcc83308f8c1a73f1d60fcc