### PR TITLE
Fix altRTDiameter and vertex variable issues

### DIFF
--- a/shaders/composite.fsh
+++ b/shaders/composite.fsh
@@ -1,7 +1,7 @@
 // File: shaders/composite.fsh
 #version 330 compatibility
 
-in vec4 texcoord;
+in vec2 texCoordOut;
 flat in vec3 colorSkyUp;
 #include "lib/Settings.inc"
 #include "lib/Uniforms.inc"

--- a/shaders/composite.vsh
+++ b/shaders/composite.vsh
@@ -5,9 +5,10 @@
 #include "lib/Uniforms.inc"
 #include "lib/Common.inc"
 layout(location = 0) in vec4 vertex;
-layout(location = 2) in vec2 texcoord;
-out vec4 texcoord;
-void main(){
- texcoord=texcoord;
- gl_Position=vertex;
+layout(location = 2) in vec2 texCoordIn;
+out vec2 texCoordOut;
+
+void main() {
+    texCoordOut = texCoordIn;
+    gl_Position = vertex;
 }

--- a/shaders/final.fsh
+++ b/shaders/final.fsh
@@ -1,7 +1,7 @@
 // File: shaders/final.fsh
 #version 330 compatibility
 
-in vec4 texcoord;
+in vec2 texCoordOut;
 #include "lib/Uniforms.inc"
 #include "lib/Common.inc"
 layout(location = 0) out vec4 fragColor;

--- a/shaders/lib/Common.inc
+++ b/shaders/lib/Common.inc
@@ -2,6 +2,19 @@
 #include "DataPacking.inc"
 #include "TAA.inc"
 
+// Default ray tracing grid settings used when the loader does not provide them
+#ifndef RAY_TRACING_DIAMETER
+#define RAY_TRACING_DIAMETER 16
+#endif
+
+#ifndef RAY_TRACING_RESOLUTION
+#define RAY_TRACING_RESOLUTION RAY_TRACING_DIAMETER
+#endif
+
+#ifndef altRTDiameter
+#define altRTDiameter RAY_TRACING_DIAMETER
+#endif
+
 #define SKYLIGHT_BRIGHTNESS 1.0
 #define MOON_BRIGHTNESS 1.0
 #define SUNLIGHT_RED 1.15

--- a/shaders/program/final.fsh.glsl
+++ b/shaders/program/final.fsh.glsl
@@ -3,7 +3,7 @@
 #include "../lib/Settings.inc"
 #include "../lib/Uniforms.inc"
 #include "../lib/Common.inc"
-in vec4 texcoord;
+in vec2 texCoordOut;
 vec3 ACESFilm(vec3 x) {
     float a = 2.51;
     float b = 0.03;
@@ -13,7 +13,7 @@ vec3 ACESFilm(vec3 x) {
     return clamp((x*(a*x+b))/(x*(c*x+d)+e), 0.0, 1.0);
 }
 void main(){
- vec3 color = texture(colortex0, texcoord.xy).rgb;
+ vec3 color = texture(colortex0, texCoordOut.xy).rgb;
  color = ACESFilm(color);
  gl_FragColor = vec4(color, 1.0);
 }


### PR DESCRIPTION
## Summary
- rename composite vertex shader variable
- define default ray tracing constants so shaders compile
- adjust varying usage in composite and final shaders

## Testing
- `glslangValidator --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843525a6d888330ba4d7fa72b8dea98