### PR TITLE
Fix duplicate GetTerrainColor definition

### DIFF
--- a/shaders/composite.fsh
+++ b/shaders/composite.fsh
@@ -6,7 +6,6 @@ flat in vec3 colorSkyUp;
 #include "lib/Settings.inc"
 #include "lib/Uniforms.inc"
 #include "lib/Common.inc"
-#include "lib/Materials.inc"
 #include "lib/GBufferData.inc"
 layout(location = 0) out vec3 FragColor0;
 layout(location = 1) out vec3 FragColor1;


### PR DESCRIPTION
## Summary
- remove extra `Materials.inc` include from `shaders/composite.fsh`

This prevents a double definition of `GetTerrainColor` that caused shader compilation errors.

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools glslc`
- `glslc -std=330 -Ishaders -Ishaders/lib -fshader-stage=frag shaders/composite.fsh -o /tmp/composite.spv` *(fails: non-Vulkan compliant code)*

------
https://chatgpt.com/codex/tasks/task_e_6843601155948330adabae2ec5c3ca6f