### PR TITLE
Resolve shader output location conflict

### DIFF
--- a/shaders/composite.fsh
+++ b/shaders/composite.fsh
@@ -7,9 +7,5 @@ flat in vec3 colorSkyUp;
 #include "lib/Uniforms.inc"
 #include "lib/Common.inc"
 #include "lib/GBufferData.inc"
-layout(location = 0) out vec3 FragColor0;
-layout(location = 1) out vec3 FragColor1;
-layout(location = 2) out vec3 FragColor2;
-layout(location = 3) out vec3 FragColor3;
 vec4 sampleDepth(vec2 uv){return texture(depthtex1, uv);}
 #include "program/composite.fsh.glsl"


### PR DESCRIPTION
## Summary
- fix overlapping output assignments in `composite.fsh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684361015f2c8330b801bd499f6b3957