### PR TITLE
Remove unused Common include from final shader

### DIFF
--- a/shaders/final.fsh
+++ b/shaders/final.fsh
@@ -3,6 +3,5 @@
 
 in vec2 texCoordOut;
 #include "lib/Uniforms.inc"
-#include "lib/Common.inc"
 layout(location = 0) out vec4 fragColor;
 #include "program/final.fsh.glsl"

--- a/shaders/program/final.fsh.glsl
+++ b/shaders/program/final.fsh.glsl
@@ -2,7 +2,6 @@
 #extension GL_ARB_gpu_shader5 : enable
 #include "../lib/Settings.inc"
 #include "../lib/Uniforms.inc"
-#include "../lib/Common.inc"
 in vec2 texCoordOut;
 vec3 ACESFilm(vec3 x) {
     float a = 2.51;


### PR DESCRIPTION
## Summary
- remove `Common.inc` from `final.fsh`
- drop unused include in `program/final.fsh.glsl`

These includes referenced code that used an undeclared `Ray` type, leading to shader compilation errors. Removing them avoids the unresolved identifier while keeping the shader's behavior the same.

## Testing
- `apt-get update`
- `apt-get install -y glslang-tools`
- `glslangValidator -S frag shaders/final.fsh` *(fails: `#include` directive not recognized by glslangValidator)*

------
https://chatgpt.com/codex/tasks/task_e_68436700d79c833094946300140435f2