### PR TITLE
Fix texCoordOut redefinition

### DIFF
--- a/shaders/program/final.fsh.glsl
+++ b/shaders/program/final.fsh.glsl
@@ -1,7 +1,6 @@
 // File: shaders/program/final.fsh.glsl
 #extension GL_ARB_gpu_shader5 : enable
 #include "../lib/Settings.inc"
-in vec2 texCoordOut;
 vec3 ACESFilm(vec3 x) {
     float a = 2.51;
     float b = 0.03;


### PR DESCRIPTION
## Summary
- remove redundant texCoordOut declaration in `shaders/program/final.fsh.glsl`

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68436b1526548330830ebe5cb10b764b