### PR TITLE
Fix duplicate include causing shader redefinition errors

### DIFF
--- a/shaders/gbuffers_terrain.fsh
+++ b/shaders/gbuffers_terrain.fsh
@@ -2,4 +2,3 @@
 #version 430 compatibility
 
 #include "program/gbuffer/terrain.fsh"
-#include "program/gbuffer/terrain.fsh"

--- a/shaders/world-1/gbuffers_block.fsh
+++ b/shaders/world-1/gbuffers_block.fsh
@@ -1,4 +1,3 @@
 // File: shaders/world-1/gbuffers_block.fsh
 #version 430 compatibility
 #include "../program/gbuffer/solid.fsh"
-#include "../program/gbuffer/solid.fsh"

--- a/shaders/world-1/gbuffers_terrain.fsh
+++ b/shaders/world-1/gbuffers_terrain.fsh
@@ -1,4 +1,3 @@
 // File: shaders/world-1/gbuffers_terrain.fsh
 #version 430 compatibility
 #include "../program/gbuffer/terrain.fsh"
-#include "../program/gbuffer/terrain.fsh"


### PR DESCRIPTION
## Summary
- remove accidental duplicate includes from several shaders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68436f6bb5b0833094e67c584360f10e