### PR TITLE
Fix terrain shader variable conflict

### DIFF
--- a/shaders/program/gbuffer/terrain.gsh
+++ b/shaders/program/gbuffer/terrain.gsh
@@ -1,8 +1,8 @@
 // File: shaders/program/gbuffers_terrain.gsh.glsl
 layout(triangles) in;
 layout(triangle_strip, max_vertices = 3) out;
-in vec4 gbufferCoord[];
-in vec3 gbufferNormal[];
+in vec4 gbufferCoordIn[];
+in vec3 gbufferNormalIn[];
 out vec4 gbufferCoord;
 out vec3 gbufferNormal;
 void main(){


### PR DESCRIPTION
## Summary
- avoid `gbufferCoord` redefinition in geometry stage by renaming inputs

## Testing
- `glslangValidator -S geom /tmp/combined.gsh`

------
https://chatgpt.com/codex/tasks/task_e_684370a66da08330b6c72102fe6de8c9