### PR TITLE
Fix missing uniform in terrain geometry shaders

### DIFF
--- a/shaders/gbuffers_terrain.gsh
+++ b/shaders/gbuffers_terrain.gsh
@@ -1,3 +1,4 @@
 // File: shaders/gbuffers_terrain.gsh
 #version 430 compatibility
+#include "lib/Uniforms.inc"
 #include "program/gbuffer/terrain.gsh"

--- a/shaders/world-1/gbuffers_terrain.gsh
+++ b/shaders/world-1/gbuffers_terrain.gsh
@@ -1,3 +1,4 @@
 // File: shaders/world-1/gbuffers_terrain.gsh
 #version 430 compatibility
+#include "../lib/Uniforms.inc"
 #include "../program/gbuffer/terrain.gsh"


### PR DESCRIPTION
## Summary
- include `lib/Uniforms.inc` in `gbuffers_terrain.gsh`
- include `../lib/Uniforms.inc` in `world-1/gbuffers_terrain.gsh`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845cfab1090833097bbe2caf191ddf3